### PR TITLE
Use .text instead of .chunk

### DIFF
--- a/src/app/utils/context.ts
+++ b/src/app/utils/context.ts
@@ -25,7 +25,7 @@ export const getContext = async (message: string, namespace: string, maxTokens =
     return qualifyingDocs
   }
 
-  let docs = matches ? qualifyingDocs.map(match => (match.metadata as Metadata).chunk) : [];
+  let docs = matches ? qualifyingDocs.map(match => (match.metadata as Metadata).text) : [];
   // Join all the chunks of text together, truncate to the maximum number of tokens, and return the result
   return docs.join("\n").substring(0, maxTokens)
 }


### PR DESCRIPTION
The metadata that I get from pinecone has no field called Chunk. This seemed to work for me.

## Problem

Example doesn't work

## Solution

Use .text instead of .chunk

